### PR TITLE
Added optional MQTT connector to the fabric8-mq

### DIFF
--- a/apps/fabric8-mq/pom.xml
+++ b/apps/fabric8-mq/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>activemq-leveldb-store</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-mqtt</artifactId>
+      <version>5.10.0</version><!-- Added to BOM in https://github.com/fabric8io/fabric8/pull/3374 -->
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <!-- Note: need to override guava version as leveldb has an issue with > 15.0 -->

--- a/apps/fabric8-mq/src/test/java/io/fabric8/mq/MqttConnectorTest.java
+++ b/apps/fabric8-mq/src/test/java/io/fabric8/mq/MqttConnectorTest.java
@@ -1,0 +1,21 @@
+package io.fabric8.mq;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MqttConnectorTest extends Assert {
+
+    @Test
+    public void shouldReturnNoPort() {
+        System.clearProperty("org.apache.activemq.AMQ_MQTT_PORT");
+        assertNull(Main.mqttPortString());
+    }
+
+    @Test
+    public void shouldReturnPortFromSystemProperty() {
+        String port = 1234 + "";
+        System.setProperty("org.apache.activemq.AMQ_MQTT_PORT", port);
+        assertEquals(port, Main.mqttPortString());
+    }
+
+}


### PR DESCRIPTION
Hi,

Now it is possible to start broker with the MQTT connector:

    docker run -p 1883:1883 -e AMQ_MQTT_PORT=1883 -it dockerhost:5000/fabric8/fabric8-mq:2.1-SNAPSHOT

IMHO we should add similar options for AMQP, STOMP and other AMQ transports.

Cheers.