### PR TITLE
Fixed version numbers in activemq app bash scripts

### DIFF
--- a/apps/fabric8-mq-autoscaler/build-and-run.sh
+++ b/apps/fabric8-mq-autoscaler/build-and-run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mvn clean install docker:build
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-autoscaler:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-autoscaler:2.2-SNAPSHOT
 mvn fabric8:deploy

--- a/apps/fabric8-mq-autoscaler/push.sh
+++ b/apps/fabric8-mq-autoscaler/push.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-autoscaler:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-autoscaler:2.2-SNAPSHOT

--- a/apps/fabric8-mq-consumer/build-push-deploy.sh
+++ b/apps/fabric8-mq-consumer/build-push-deploy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mvn clean install docker:build
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-consumer:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-consumer:2.2-SNAPSHOT
 mvn fabric8:json fabric8:deploy

--- a/apps/fabric8-mq-consumer/build-push-run.sh
+++ b/apps/fabric8-mq-consumer/build-push-run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mvn clean install docker:build
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-consumer:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-consumer:2.2-SNAPSHOT
 mvn fabric8:json fabric8:run

--- a/apps/fabric8-mq-consumer/push.sh
+++ b/apps/fabric8-mq-consumer/push.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-consumer:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-consumer:2.2-SNAPSHOT

--- a/apps/fabric8-mq-producer/build-push-deploy.sh
+++ b/apps/fabric8-mq-producer/build-push-deploy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mvn clean install docker:build
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-producer:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-producer:2.2-SNAPSHOT
 mvn fabric8:json fabric8:deploy

--- a/apps/fabric8-mq-producer/build-push-run.sh
+++ b/apps/fabric8-mq-producer/build-push-run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mvn clean install docker:build
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-producer:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-producer:2.2-SNAPSHOT
 mvn fabric8:json fabric8:run

--- a/apps/fabric8-mq-producer/push.sh
+++ b/apps/fabric8-mq-producer/push.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-producer:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq-producer:2.2-SNAPSHOT

--- a/apps/fabric8-mq/build-push-deploy.sh
+++ b/apps/fabric8-mq/build-push-deploy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mvn clean install docker:build
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq:2.2-SNAPSHOT
 mvn fabric8:json fabric8:deploy

--- a/apps/fabric8-mq/build-push-run.sh
+++ b/apps/fabric8-mq/build-push-run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mvn clean install docker:build
-docker push $DOCKER_REGISTRY/fabric8/fabric8-mq:2.0-SNAPSHOT
+docker push $DOCKER_REGISTRY/fabric8/fabric8-mq:2.2-SNAPSHOT
 mvn fabric8:json fabric8:run


### PR DESCRIPTION
ActiveMQ projects are on 2.2-SNAPSHOT, but bash scripts still refer to 2.0-SNAPSHOT