### PR TITLE
lets disable the jgroups quickstart for now so that the release can go through while we figure out the docker release issues

### DIFF
--- a/quickstarts/java/pom.xml
+++ b/quickstarts/java/pom.xml
@@ -42,7 +42,10 @@
     <module>cxf-cdi</module>
     <module>simple-mainclass</module>
     <module>simple-fatjar</module>
+<!--
+    TODO
     <module>jgroups-greeter</module>
+-->
   </modules>
 
   <build>


### PR DESCRIPTION
lets disable the jgroups quickstart for now so that the release can go through while we figure out the docker release issues