### PR TITLE
Setting correct ownership for the wildfly files

### DIFF
--- a/apps/apiman/pom.xml
+++ b/apps/apiman/pom.xml
@@ -38,6 +38,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <version.maven-surefire-plugin>2.15</version.maven-surefire-plugin>
     <version.maven-bundle-plugin>2.3.7</version.maven-bundle-plugin>
+    <docker.maven.plugin.version>0.11.1</docker.maven.plugin.version>
     <apiman.version>1.0.1.Final</apiman.version>
 
     <http.port>8080</http.port>
@@ -49,7 +50,7 @@
     <txn.status.manager.port>4713</txn.status.manager.port>
 
     <!-- TODO no such docker image - what should it be?? -->
-    <!--
+    <!-- the Jube image is wildfly/default, we should rename it to jboss/wildfly to be consistent with the docker image 
     <docker.from>wildfly/default</docker.from>
     -->
     <docker.from>jboss/wildfly</docker.from>
@@ -181,7 +182,8 @@
                 <from>${docker.from}</from>
                 <assembly>
                   <descriptor>${docker.assemblyDescriptor}</descriptor>
-                  <basedir>/opt/wildfly-8.2.0.Final</basedir>
+                  <basedir>/opt/jboss/</basedir>
+                  <dockerFileDir>${basedir}/src/main/docker</dockerFileDir>
                 </assembly>
               </build>
             </image>
@@ -245,6 +247,7 @@
             <configuration>
               <assemblyDescriptor>${project.build.directory}/fabric8/assembly.xml</assemblyDescriptor>
               <exportDir>/</exportDir>
+              <owner>jboss</owner>
             </configuration>
           </plugin>
         </plugins>

--- a/apps/apiman/pom.xml
+++ b/apps/apiman/pom.xml
@@ -38,7 +38,6 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <version.maven-surefire-plugin>2.15</version.maven-surefire-plugin>
     <version.maven-bundle-plugin>2.3.7</version.maven-bundle-plugin>
-    <docker.maven.plugin.version>0.11.1</docker.maven.plugin.version>
     <apiman.version>1.0.1.Final</apiman.version>
 
     <http.port>8080</http.port>
@@ -247,7 +246,6 @@
             <configuration>
               <assemblyDescriptor>${project.build.directory}/fabric8/assembly.xml</assemblyDescriptor>
               <exportDir>/</exportDir>
-              <owner>jboss</owner>
             </configuration>
           </plugin>
         </plugins>

--- a/apps/apiman/src/main/docker/Dockerfile
+++ b/apps/apiman/src/main/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM jboss/wildfly:8.2.0.Final
+MAINTAINER docker-maven-plugin@jolokia.org
+ADD maven /opt/jboss/
+USER root
+RUN chown -R jboss:jboss /opt/jboss
+USER jboss
+CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-c", "standalone-apiman.xml"]


### PR DESCRIPTION
Note that the jube image should be renamed to jboss/wildfly to be consistent with the docker naming.