### PR TITLE
lets move archetype generation to the front of the build to try fix the broken group app-zip generation; also lets use a nicer group and artifact for the archetype catalog build

### DIFF
--- a/archetypes-catalog/pom.xml
+++ b/archetypes-catalog/pom.xml
@@ -26,7 +26,8 @@
     <version>2.2-SNAPSHOT</version>
   </parent>
 
-  <artifactId>fabric8-archetypes-generate</artifactId>
+  <groupId>io.fabric8.archetypes</groupId>
+  <artifactId>archetypes-catalog</artifactId>
   <packaging>pom</packaging>
   <name>Archetypes :: Generate</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,10 +104,10 @@
 
     <modules>
         <module>rest-utils</module>
+        <module>archetypes-catalog</module>
+        <module>archetypes</module>
         <module>apps</module>
         <module>quickstarts</module>
-        <module>archetypes-generate</module>
-        <module>archetypes</module>
     </modules>
 
     <build>


### PR DESCRIPTION
lets move archetype generation to the front of the build to try fix the broken group app-zip generation; also lets use a nicer group and artifact for the archetype catalog build