### PR TITLE
Updating image name to new ruby-20-centos7

### DIFF
--- a/apps/jenkins/src/main/fabric8/kubernetes.json
+++ b/apps/jenkins/src/main/fabric8/kubernetes.json
@@ -71,7 +71,7 @@
                 },
                 "strategy":{
                     "stiStrategy":{
-                        "builderImage":"openshift/ruby-20-centos"
+                        "builderImage":"openshift/ruby-20-centos7"
                     },
                     "type":"STI"
                 }
@@ -99,7 +99,7 @@
                 },
                 "strategy":{
                     "stiStrategy":{
-                        "builderImage":"openshift/ruby-20-centos"
+                        "builderImage":"openshift/ruby-20-centos7"
                     },
                     "type":"STI"
                 }


### PR DESCRIPTION
There is a new ruby-20 image(ruby-20-centos7) and we are going to get rid of the old one(ruby-20-centos)