### PR TITLE
disable https on gogs for now until we've a valid cert so that STI and Orion can clone from https on gogs

### DIFF
--- a/apps/gogs/pom.xml
+++ b/apps/gogs/pom.xml
@@ -38,9 +38,16 @@
     <docker.port.container.ssh>22</docker.port.container.ssh>
     <docker.port.container.jolokia />
 
-    <fabric8.env.GOGS_SERVER__DOMAIN>gogs.fabric8.local</fabric8.env.GOGS_SERVER__DOMAIN>
-    <fabric8.env.GOGS_SERVER__ROOT_URL>https://gogs.fabric8.local</fabric8.env.GOGS_SERVER__ROOT_URL>
+    <domain>fabric8.local</domain>
+    <fabric8.env.GOGS_SERVER__DOMAIN>gogs.${domain}</fabric8.env.GOGS_SERVER__DOMAIN>
+    <fabric8.env.GOGS_SERVER__ROOT_URL>http://gogs.${domain}</fabric8.env.GOGS_SERVER__ROOT_URL>
+    <fabric8.env.GOGS_SERVER__PROTOCOL>http</fabric8.env.GOGS_SERVER__PROTOCOL>
+<!--
+    TODO re-enable when we have certs so that STI builds and Eclipse Orion can clone the repo from https://
+
+    <fabric8.env.GOGS_SERVER__ROOT_URL>https://gogs.${domain}</fabric8.env.GOGS_SERVER__ROOT_URL>
     <fabric8.env.GOGS_SERVER__PROTOCOL>https</fabric8.env.GOGS_SERVER__PROTOCOL>
+-->
     <fabric8.env.GOGS_WEBHOOK__SKIP_TLS_VERIFY>true</fabric8.env.GOGS_WEBHOOK__SKIP_TLS_VERIFY>
     <fabric8.env.GOGS_WEBHOOK__TASK_INTERVAL>true</fabric8.env.GOGS_WEBHOOK__TASK_INTERVAL>
 


### PR DESCRIPTION
disable https on gogs for now until we've a valid cert so that STI and Orion can clone from https on gogs