### PR TITLE
use port 80 for gogs for now so it matches the http protocol

### DIFF
--- a/apps/gogs/pom.xml
+++ b/apps/gogs/pom.xml
@@ -47,13 +47,14 @@
 
     <fabric8.env.GOGS_SERVER__ROOT_URL>https://gogs.${domain}</fabric8.env.GOGS_SERVER__ROOT_URL>
     <fabric8.env.GOGS_SERVER__PROTOCOL>https</fabric8.env.GOGS_SERVER__PROTOCOL>
+    <fabric8.service.port>443</fabric8.service.port>
 -->
     <fabric8.env.GOGS_WEBHOOK__SKIP_TLS_VERIFY>true</fabric8.env.GOGS_WEBHOOK__SKIP_TLS_VERIFY>
     <fabric8.env.GOGS_WEBHOOK__TASK_INTERVAL>true</fabric8.env.GOGS_WEBHOOK__TASK_INTERVAL>
+    <fabric8.service.port>80</fabric8.service.port>
 
     <fabric8.replicationController.name>gogs-controller</fabric8.replicationController.name>
     <fabric8.service.name>gogs-http-service</fabric8.service.name>
-    <fabric8.service.port>443</fabric8.service.port>
     <fabric8.service.containerPort>3000</fabric8.service.containerPort>
     <fabric8.imagePullPolicy>PullIfNotPresent</fabric8.imagePullPolicy>
 


### PR DESCRIPTION
use port 80 for gogs for now so it matches the http protocol