### PR TITLE
switch to use the new fabric8 jenkins image which comes with out of the box maven integration

### DIFF
--- a/apps/jenkins/src/main/fabric8/kubernetes.json
+++ b/apps/jenkins/src/main/fabric8/kubernetes.json
@@ -30,7 +30,7 @@
                             "version" : "v1beta1",
                             "id" : "jenkinsPod",
                             "containers" : [ {
-                                "image":"rawlingsj/fabric8-jenkins",
+                                "image":"fabric8/jenkins",
                                 "name":"jenkins-container",
                                 "ports":[
                                     {


### PR DESCRIPTION
switch to use the new fabric8 jenkins image which comes with out of the box maven integration