### PR TITLE
disable the use of registry prefixes in the docker image names

### DIFF
--- a/app-groups/cdelivery/pom.xml
+++ b/app-groups/cdelivery/pom.xml
@@ -105,7 +105,7 @@
     </dependency>
     <dependency>
       <groupId>io.fabric8.jube.images.fabric8</groupId>
-      <artifactId>lets-chat</artifactId>
+      <artifactId>letschat</artifactId>
       <version>${project.version}</version>
       <classifier>kubernetes</classifier>
       <type>json</type>

--- a/apps/api-registry/pom.xml
+++ b/apps/api-registry/pom.xml
@@ -50,8 +50,8 @@
     <http.port>8080</http.port>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.env.MAIN>io.fabric8.api.registry.Main</docker.env.MAIN>
     <docker.port.container.http>${http.port}</docker.port.container.http>

--- a/apps/apiman-manager-api/pom.xml
+++ b/apps/apiman-manager-api/pom.xml
@@ -31,8 +31,8 @@
     <http.port>7070</http.port>
     
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.env.MAIN>io.fabric8.apiman.Starter</docker.env.MAIN>
     <docker.port.container.http>${http.port}</docker.port.container.http>
@@ -354,7 +354,6 @@
     <profile>
       <id>docker-public</id>
       <properties>
-        <docker.registryPrefix />
       </properties>
     </profile>
   </profiles>

--- a/apps/app-library/pom.xml
+++ b/apps/app-library/pom.xml
@@ -56,8 +56,8 @@
     <http.port>8080</http.port>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.env.MAIN>io.fabric8.app.library.Main</docker.env.MAIN>
     <docker.env.IMPORT_APP_URLS>mvn:io.fabric8.quickstarts/fabric8-quickstarts-parent/${fabric8.release.version}/zip/app,mvn:io.fabric8.jube.images.fabric8/apps/${fabric8.release.version}/zip/app</docker.env.IMPORT_APP_URLS>

--- a/apps/cdelivery/pom.xml
+++ b/apps/cdelivery/pom.xml
@@ -49,8 +49,8 @@
     <http.port>8787</http.port>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.env.MAIN>io.fabric8.cdelivery.Main</docker.env.MAIN>
     <docker.port.container.http>${http.port}</docker.port.container.http>

--- a/apps/hubot-notifier/pom.xml
+++ b/apps/hubot-notifier/pom.xml
@@ -42,8 +42,8 @@
     <skipTests>false</skipTests>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.env.MAIN>org.jboss.weld.environment.se.StartMain</docker.env.MAIN>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>

--- a/apps/jenkins/pom.xml
+++ b/apps/jenkins/pom.xml
@@ -68,9 +68,13 @@
         <fabric8.parameter.SEED_GIT_URL.description>The git URL of the seed build used to generate builds</fabric8.parameter.SEED_GIT_URL.description>
 
         <!-- liveness probe -->
+<!--
+        TODO lets disable for now...
+
         <fabric8.livenessProbe.httpGet.path>/v1/_ping</fabric8.livenessProbe.httpGet.path>
         <fabric8.livenessProbe.httpGet.port>2375</fabric8.livenessProbe.httpGet.port>
         <fabric8.livenessProbe.initialDelaySeconds>30</fabric8.livenessProbe.initialDelaySeconds>
+-->
 
         <!-- add certs -->
         <fabric8.volume.openshift-cert-secrets.secret>openshift-cert-secrets</fabric8.volume.openshift-cert-secrets.secret>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -37,8 +37,8 @@
         <amqbroker.service.port>7163</amqbroker.service.port>
 
         <docker.from>fabric8/java</docker.from>
-        <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-        <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+        <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
         <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
         <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -130,11 +130,7 @@
       </pluginRepository>
     </pluginRepositories>
 
-  <modules>
-        <module>archetypes-catalog</module>
-        <module>archetypes</module>
-        <module>apps</module>
-        <module>quickstarts</module>
+    <modules>
     </modules>
 
     <build>
@@ -372,6 +368,27 @@
           <id>canary</id>
           <modules>
             <module>app-groups</module>
+          </modules>
+        </profile>
+        <profile>
+          <id>apps</id>
+          <activation>
+            <activeByDefault>true</activeByDefault>
+          </activation>
+          <modules>
+            <module>apps</module>
+            <module>app-groups</module>
+          </modules>
+        </profile>
+        <profile>
+          <id>quickstarts</id>
+          <activation>
+            <activeByDefault>true</activeByDefault>
+          </activation>
+          <modules>
+            <module>archetypes-catalog</module>
+            <module>archetypes</module>
+            <module>quickstarts</module>
           </modules>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -77,19 +77,14 @@
         <maven.compiler.target>1.7</maven.compiler.target>
 
         <docker.source.dir>${basedir}/src/main/docker</docker.source.dir>
-<!--
-        <docker.target.dir>${basedir}/target/docker-plugin</docker.target.dir>
--->
 
         <arquillian.version>1.1.5.Final</arquillian.version>
         <docker.maven.plugin.version>0.11.3</docker.maven.plugin.version>
+        <docker.registryPrefix></docker.registryPrefix>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <maven.surefire.plugin.version>2.17</maven.surefire.plugin.version>
         <jube.version>2.0.48</jube.version>
         <junit.version>4.12</junit.version>
-<!--
-        <fabric8.version>2.2-SNAPSHOT</fabric8.version>
--->
         <fabric8.version>2.2-SNAPSHOT</fabric8.version>
         <maven.require.version>3.1.1</maven.require.version>
         <maven.enforcer.plugin.version>1.3.1</maven.enforcer.plugin.version>
@@ -290,13 +285,6 @@
             <jube.version>2.0-SNAPSHOT</jube.version>
           </properties>
         </profile>
-
-      <profile>
-        <id>docker-public</id>
-        <properties>
-          <docker.registryPrefix>registry.hub.docker.com/</docker.registryPrefix>
-        </properties>
-      </profile>
 
         <profile>
             <id>release</id>

--- a/quickstarts/java/camel-cdi-mq/pom.xml
+++ b/quickstarts/java/camel-cdi-mq/pom.xml
@@ -50,8 +50,8 @@
     <jube.version>2.0.48</jube.version>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.env.MAIN>org.apache.camel.cdi.Main</docker.env.MAIN>

--- a/quickstarts/java/camel-cdi/pom.xml
+++ b/quickstarts/java/camel-cdi/pom.xml
@@ -53,8 +53,8 @@
     <docker.maven.plugin.version>0.11.3</docker.maven.plugin.version>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.env.MAIN>org.apache.camel.cdi.Main</docker.env.MAIN>

--- a/quickstarts/java/camel-spring/pom.xml
+++ b/quickstarts/java/camel-spring/pom.xml
@@ -54,8 +54,8 @@
     <docker.maven.plugin.version>0.11.3</docker.maven.plugin.version>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.env.MAIN>org.apache.camel.spring.Main</docker.env.MAIN>

--- a/quickstarts/java/cxf-cdi/pom.xml
+++ b/quickstarts/java/cxf-cdi/pom.xml
@@ -57,8 +57,8 @@
     <http.port>9092</http.port>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.env.MAIN>io.fabric8.quickstarts.cxfcdi.ApplicationStarter</docker.env.MAIN>
     <docker.port.container.http>${http.port}</docker.port.container.http>

--- a/quickstarts/java/jgroups-greeter/pom.xml
+++ b/quickstarts/java/jgroups-greeter/pom.xml
@@ -41,8 +41,8 @@
         <docker.maven.plugin.version>0.11.3</docker.maven.plugin.version>
 
         <docker.from>fabric8/java</docker.from>
-        <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-        <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+        <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
         <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
         <docker.port.container.jolokia>8778</docker.port.container.jolokia>
         <docker.port.container.jgroups>7800</docker.port.container.jgroups>

--- a/quickstarts/java/simple-fatjar/pom.xml
+++ b/quickstarts/java/simple-fatjar/pom.xml
@@ -47,8 +47,8 @@
     <docker.maven.plugin.version>0.11.3</docker.maven.plugin.version>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.env.JAR>${project.artifactId}-${project.version}.jar</docker.env.JAR>

--- a/quickstarts/java/simple-mainclass/pom.xml
+++ b/quickstarts/java/simple-mainclass/pom.xml
@@ -47,8 +47,8 @@
     <docker.maven.plugin.version>0.11.3</docker.maven.plugin.version>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact-with-dependencies</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.env.MAIN>io.fabric8.quickstarts.java.simple.Main</docker.env.MAIN>

--- a/quickstarts/karaf/beginner/camel-cbr/pom.xml
+++ b/quickstarts/karaf/beginner/camel-cbr/pom.xml
@@ -46,8 +46,8 @@
     <camel.version>2.15.2</camel.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camelcbr:${project.version}</docker.image>
+
+    <docker.image>fabric8/quickstart-karaf-camelcbr:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/beginner/camel-eips/pom.xml
+++ b/quickstarts/karaf/beginner/camel-eips/pom.xml
@@ -45,8 +45,8 @@
     <camel.version>2.15.2</camel.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-cameleip:${project.version}</docker.image>
+
+    <docker.image>fabric8/quickstart-karaf-cameleip:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/beginner/camel-errorhandler/pom.xml
+++ b/quickstarts/karaf/beginner/camel-errorhandler/pom.xml
@@ -46,8 +46,8 @@
     <camel.version>2.15.2</camel.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camelerr:${project.version}</docker.image>
+
+    <docker.image>fabric8/quickstart-karaf-camelerr:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/beginner/camel-log-wiki/pom.xml
+++ b/quickstarts/karaf/beginner/camel-log-wiki/pom.xml
@@ -46,8 +46,8 @@
     <camel.version>2.15.2</camel.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camelwiki:${project.version}</docker.image>
+
+    <docker.image>fabric8/quickstart-karaf-camelwiki:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/beginner/camel-log/pom.xml
+++ b/quickstarts/karaf/beginner/camel-log/pom.xml
@@ -46,8 +46,8 @@
     <camel.version>2.15.2</camel.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camellog:${project.version}</docker.image>
+
+    <docker.image>fabric8/quickstart-karaf-camellog:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/camel-amq/pom.xml
+++ b/quickstarts/karaf/camel-amq/pom.xml
@@ -46,8 +46,8 @@
     <karaf.version>2.4.0</karaf.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/camel-dozer-wiki/pom.xml
+++ b/quickstarts/karaf/camel-dozer-wiki/pom.xml
@@ -46,8 +46,8 @@
     <camel.version>2.15.2</camel.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/camel-drools/pom.xml
+++ b/quickstarts/karaf/camel-drools/pom.xml
@@ -49,8 +49,8 @@
     <drools.version>${drools.version}</drools.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/camel-rest-sql/pom.xml
+++ b/quickstarts/karaf/camel-rest-sql/pom.xml
@@ -47,8 +47,8 @@
     <derby.version>10.10.2.0</derby.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camelrest:${project.version}</docker.image>
+
+    <docker.image>fabric8/quickstart-karaf-camelrest:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/cxf/camel-cxf-code-first/pom.xml
+++ b/quickstarts/karaf/cxf/camel-cxf-code-first/pom.xml
@@ -45,8 +45,8 @@
     <karaf.version>2.4.0</karaf.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/cxf/camel-cxf-contract-first/pom.xml
+++ b/quickstarts/karaf/cxf/camel-cxf-contract-first/pom.xml
@@ -48,8 +48,8 @@
     <karaf.version>2.4.0</karaf.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/cxf/rest/pom.xml
+++ b/quickstarts/karaf/cxf/rest/pom.xml
@@ -62,8 +62,8 @@
     <swagger-scala-version>2.10.2</swagger-scala-version>
  
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/cxf/secure-rest/pom.xml
+++ b/quickstarts/karaf/cxf/secure-rest/pom.xml
@@ -61,8 +61,8 @@
 
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/cxf/secure-soap/pom.xml
+++ b/quickstarts/karaf/cxf/secure-soap/pom.xml
@@ -47,8 +47,8 @@
     <cxf.version>3.0.4</cxf.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/cxf/soap/pom.xml
+++ b/quickstarts/karaf/cxf/soap/pom.xml
@@ -51,8 +51,8 @@
     <karaf.version>2.4.0</karaf.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/karaf/profiles/camel-twitter/pom.xml
+++ b/quickstarts/karaf/profiles/camel-twitter/pom.xml
@@ -47,8 +47,8 @@
     <karaf.version>2.4.0</karaf.version>
 
     <docker.from>fabric8/karaf-2.4</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/quickstart-karaf-camelcbr:${project.version}</docker.image>
+
+    <docker.image>fabric8/quickstart-karaf-camelcbr:${project.version}</docker.image>
     <docker.assemblyDescriptor>${basedir}/src/main/fabric8/assembly.xml</docker.assemblyDescriptor>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8181</docker.port.container.http>

--- a/quickstarts/spring-boot/activemq/pom.xml
+++ b/quickstarts/spring-boot/activemq/pom.xml
@@ -49,8 +49,8 @@
     <spring-boot-plugin.version>1.2.3.RELEASE</spring-boot-plugin.version>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
     <docker.env.JAR>${project.artifactId}-${project.version}.jar</docker.env.JAR>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>

--- a/quickstarts/spring-boot/camel/pom.xml
+++ b/quickstarts/spring-boot/camel/pom.xml
@@ -50,8 +50,8 @@
     <spring-boot.version>1.2.3.RELEASE</spring-boot.version>
 
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
     <docker.env.JAR>${project.artifactId}-${project.version}.jar</docker.env.JAR>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>

--- a/quickstarts/spring-boot/keycloak/pom.xml
+++ b/quickstarts/spring-boot/keycloak/pom.xml
@@ -52,8 +52,8 @@
 
     <!-- fabric8 configuration -->
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
     <docker.env.JAR>${project.artifactId}-${project.version}.jar</docker.env.JAR>
     <docker.port.container.http>8080</docker.port.container.http>

--- a/quickstarts/spring-boot/webmvc-ip/pom.xml
+++ b/quickstarts/spring-boot/webmvc-ip/pom.xml
@@ -50,8 +50,8 @@
 
     <!-- fabric8 configuration -->
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
     <docker.env.JAR>${project.artifactId}-${project.version}.jar</docker.env.JAR>
     <docker.port.container.http>8080</docker.port.container.http>

--- a/quickstarts/spring-boot/webmvc/pom.xml
+++ b/quickstarts/spring-boot/webmvc/pom.xml
@@ -50,8 +50,8 @@
 
     <!-- fabric8 configuration -->
     <docker.from>fabric8/java</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
     <docker.env.JAR>${project.artifactId}-${project.version}.jar</docker.env.JAR>
     <docker.port.container.http>8080</docker.port.container.http>

--- a/quickstarts/war/camel-servlet/pom.xml
+++ b/quickstarts/war/camel-servlet/pom.xml
@@ -45,8 +45,8 @@
     <fabric8.version>2.2-SNAPSHOT</fabric8.version>
 
     <docker.from>fabric8/tomcat-8.0</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>rootWar</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8080</docker.port.container.http>

--- a/quickstarts/war/cxf-cdi-servlet/pom.xml
+++ b/quickstarts/war/cxf-cdi-servlet/pom.xml
@@ -48,8 +48,8 @@
     <org.eclipse.jetty.version>9.1.5.v20140505</org.eclipse.jetty.version>
     
     <docker.from>fabric8/tomcat-8.0</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>rootWar</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8080</docker.port.container.http>

--- a/quickstarts/war/rest/pom.xml
+++ b/quickstarts/war/rest/pom.xml
@@ -52,8 +52,8 @@
     <cxf.version>3.0.4</cxf.version>
 
     <docker.from>fabric8/tomcat-8.0</docker.from>
-    <docker.registryPrefix>${env.DOCKER_REGISTRY}/</docker.registryPrefix>
-    <docker.image>${docker.registryPrefix}fabric8/${project.artifactId}:${project.version}</docker.image>
+
+    <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
     <docker.assemblyDescriptorRef>rootWar</docker.assemblyDescriptorRef>
     <docker.port.container.jolokia>8778</docker.port.container.jolokia>
     <docker.port.container.http>8080</docker.port.container.http>


### PR DESCRIPTION
disable the use of registry prefixes in the docker image names