### PR TITLE
app library is now not really needed for the console as we can use templates instead now

### DIFF
--- a/app-groups/base/pom.xml
+++ b/app-groups/base/pom.xml
@@ -42,13 +42,6 @@
       <classifier>kubernetes</classifier>
       <type>json</type>
     </dependency>
-    <dependency>
-      <groupId>io.fabric8.jube.images.fabric8</groupId>
-      <artifactId>app-library</artifactId>
-      <version>${project.version}</version>
-      <classifier>kubernetes</classifier>
-      <type>json</type>
-    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
app library is now not really needed for the console as we can use templates instead now