### PR TITLE
Move to Fabric 2.1.5 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <maven.surefire.plugin.version>2.17</maven.surefire.plugin.version>
         <jube.version>2.1.4</jube.version>
         <junit.version>4.12</junit.version>
-        <fabric8.version>2.1.4</fabric8.version>
+        <fabric8.version>2.1.5</fabric8.version>
         <maven.require.version>3.1.1</maven.require.version>
         <maven.enforcer.plugin.version>1.3.1</maven.enforcer.plugin.version>
     </properties>


### PR DESCRIPTION
As maven plugin 2.1.4 of fabric8 is buggy, we should move to 2.1.5