### PR TITLE
Include gerrit kube app

### DIFF
--- a/app-groups/cdelivery-core/pom.xml
+++ b/app-groups/cdelivery-core/pom.xml
@@ -60,6 +60,13 @@
     <!-- CD building stuff -->
     <dependency>
       <groupId>io.fabric8.jube.images.fabric8</groupId>
+      <artifactId>gerrit</artifactId>
+      <version>${project.version}</version>
+      <classifier>kubernetes</classifier>
+      <type>json</type>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8.jube.images.fabric8</groupId>
       <artifactId>gogs</artifactId>
       <version>${project.version}</version>
       <classifier>kubernetes</classifier>


### PR DESCRIPTION
As the new Fabric8 docker gerrit image has been tested successfully like also the gerrit kube app, we can add it to the cdelivery-core app