### PR TITLE
Adopt same convention as other services to call internally the containers

### DIFF
--- a/apps/gerrit/src/main/fabric8/env.properties
+++ b/apps/gerrit/src/main/fabric8/env.properties
@@ -1,7 +1,7 @@
 # The Hostname of the machine running the service is accessible
 # using the internal Openshift DNS server (http://docs.openshift.org/latest/architecture/additional_concepts/networking.html#openshift-dns) with this address
 # <service>.<pod_namespace>.local
-GIT_SERVER_IP = gogs-http-service.default.local
+GIT_SERVER_IP = gogs-http.default.local
 GIT_SERVER_PORT = 80
 GIT_SERVER_USER = root
 GIT_SERVER_PASSWORD = redhat01

--- a/apps/gerrit/src/main/java/io/fabric8/app/gerrit/GerritModelProcessor.java
+++ b/apps/gerrit/src/main/java/io/fabric8/app/gerrit/GerritModelProcessor.java
@@ -9,7 +9,7 @@ public class GerritModelProcessor {
     public void onList(TemplateBuilder builder) {
         builder.addNewServiceObject()
                 .withNewMetadata()
-                  .withName("gerrit-http-service")
+                  .withName("gerrit-http")
                   .addToLabels("component", "gerrit")
                   .addToLabels("provider", "fabric8")
                 .endMetadata()
@@ -26,7 +26,7 @@ public class GerritModelProcessor {
                 // Second service
                 .addNewServiceObject()
                 .withNewMetadata()
-                  .withName("gerrit-ssh-service")
+                  .withName("gerrit-ssh")
                   .addToLabels("component", "gerrit")
                   .addToLabels("provider", "fabric8")
                 .endMetadata()


### PR DESCRIPTION
Adopt same convention as other services to call internally the containers. 

- So let's remove -service from gerrit-http and gerrit-ssh service names.
- Rename the internal hostname of the gogs-http server to allow the replication to work