### PR TITLE
Change server hostname as openshift has changed the internal domain name

### DIFF
--- a/apps/gerrit/src/main/fabric8/env.properties
+++ b/apps/gerrit/src/main/fabric8/env.properties
@@ -1,7 +1,7 @@
 # The Hostname of the machine running the service is accessible
-# using the internal Openshift DNS server (http://docs.openshift.org/latest/architecture/additional_concepts/networking.html#openshift-dns) with this address
-# <service>.<pod_namespace>.local
-GIT_SERVER_IP = gogs-http.default.local
+# using the internal Openshift (v0.5.3) DNS server (http://docs.openshift.org/latest/architecture/additional_concepts/networking.html#openshift-dns) with this address
+# <service>.<pod_namespace>.svc.cluster.local
+GIT_SERVER_IP = gogs-http.default.svc.cluster.local
 GIT_SERVER_PORT = 80
 GIT_SERVER_USER = root
 GIT_SERVER_PASSWORD = redhat01


### PR DESCRIPTION
Since openshift 0.5.3, openshift has changed the internal domain name to be used to query a pod running within the namespace

They change `<service>.<namespace>.local` to `<service>.<namespace>.svc.cluster.local`. By consequence the env property `GIT_SERVER_IP` must be changed to `gogs-http.default.svc.cluster.local`.