### PR TITLE
Update Kube App to support the new Docker Gerrit Image

### DIFF
--- a/apps/gerrit/pom.xml
+++ b/apps/gerrit/pom.xml
@@ -46,7 +46,6 @@
         <fabric8.label.provider>fabric8</fabric8.label.provider>
         <!-- to access docker socket lets run in priviledged mode -->
         <fabric8.containerPrivileged>true</fabric8.containerPrivileged>
-        <fabric8.generateJson>true</fabric8.generateJson>
 
         <!--  ReplicationController  -->
         <fabric8.replicationController.name>${project.artifactId}-controller</fabric8.replicationController.name>
@@ -55,6 +54,17 @@
         <!-- Volume mounted to backup gerrit site -->
         <fabric8.volume.gerrit-workspace.hostPath>/home/gerrit-site</fabric8.volume.gerrit-workspace.hostPath>
         <fabric8.volume.gerrit-workspace.mountPath>/home/gerrit/site</fabric8.volume.gerrit-workspace.mountPath>
+
+        <!-- Volume mounted containing Users SSH Public Key (jenkins, sonar, ...) -->
+        <!-- The keys should be imported within the Virtual Box of Vagrant if used -->
+        <fabric8.volume.gerrit-users-ssh-key.hostPath>/home/gerrit/ssh-keys</fabric8.volume.gerrit-users-ssh-key.hostPath>
+        <fabric8.volume.gerrit-users-ssh-key.mountPath>/home/gerrit/ssh-keys</fabric8.volume.gerrit-users-ssh-key.mountPath>
+
+        <!-- Volume mounted Containing Private &Public Key to be used to set the Admin User of Gerrit  -->
+        <fabric8.volume.gerrit-admin-ssh-private-key.hostPath>/home/gerrit/admin-ssh-key/id_rsa</fabric8.volume.gerrit-admin-ssh-private-key.hostPath>
+        <fabric8.volume.gerrit-admin-ssh-private-key.mountPath>/root/.ssh/id_rsa</fabric8.volume.gerrit-admin-ssh-private-key.mountPath>
+        <fabric8.volume.gerrit-admin-ssh-public-key.hostPath>/home/gerrit/admin-ssh-key/id_rsa.pub</fabric8.volume.gerrit-admin-ssh-public-key.hostPath>
+        <fabric8.volume.gerrit-admin-ssh-public-key.mountPath>/root/.ssh/id_rsa.pub</fabric8.volume.gerrit-admin-ssh-public-key.mountPath>
     </properties>
 
     <build>

--- a/apps/gerrit/src/main/fabric8/env.properties
+++ b/apps/gerrit/src/main/fabric8/env.properties
@@ -1,15 +1,28 @@
 # The Hostname of the machine running the service is accessible
 # using the internal Openshift (v0.5.3) DNS server (http://docs.openshift.org/latest/architecture/additional_concepts/networking.html#openshift-dns) with this address
 # <service>.<pod_namespace>.svc.cluster.local
+
+# Replication
 GIT_SERVER_IP = gogs.default.svc.cluster.local
 GIT_SERVER_PORT = 80
 GIT_SERVER_USER = root
 GIT_SERVER_PASSWORD = redhat01
 GIT_SERVER_PROJ_ROOT = root
 
+# Create Admin User
 GERRIT_ADMIN_USER = admin
 GERRIT_ADMIN_EMAIL = admin@fabric8.io
 GERRIT_ADMIN_FULLNAME = Administrator
 GERRIT_ADMIN_PWD = secret
 
+# List of users to be created when gerrit pod is created & keys to be imported
+GERRIT_ACCOUNTS = jenkins,jenkins,jenkins@fabric8.io,secret,Non-Interactive Users:Administrators;sonar,sonar,sonar@fabric8.io,secret,Non-Interactive Users
+GERRIT_SSH_PATH = /home/gerrit/ssh-keys
+
+# Java Job changing Project Permissions when gerrit site is generated (before to be started)
+GERRIT_GIT_LOCALPATH = /home/gerrit/git
+GERRIT_GIT_PROJECT_CONFIG = /home/gerrit/configs/project.config
+GERRIT_GIT_REMOTEPATH = ssh://admin@localhost:29418/All-Projects
+
+# Authentication mode
 AUTH_TYPE = DEVELOPMENT_BECOME_ANY_ACCOUNT

--- a/apps/gerrit/src/main/java/io/fabric8/app/gerrit/GerritModelProcessor.java
+++ b/apps/gerrit/src/main/java/io/fabric8/app/gerrit/GerritModelProcessor.java
@@ -9,7 +9,7 @@ public class GerritModelProcessor {
     public void onList(TemplateBuilder builder) {
         builder.addNewServiceObject()
                 .withNewMetadata()
-                  .withName("gerrit-http")
+                  .withName("gerrit")
                   .addToLabels("component", "gerrit")
                   .addToLabels("provider", "fabric8")
                 .endMetadata()


### PR DESCRIPTION
Update gerrit kube app to support new fabric8/docker image (env vars / volumes) :

* Add missing env vars (create-user-plugin, java-job changing the permissions)
* Define the volumes (keys to be imported)
* Change link to gogs service & not anymore gogs-http
* Change gerrit-http service to gerrit service