### PR TITLE
lets delegate to the KubernetesClient and let it figure out where the master is via env vars, service discovery or the ~/.kube/config file

### DIFF
--- a/apps/fabric8mq-autoscaler/src/main/java/io/fabric8/mq/autoscaler/MQAutoScaler.java
+++ b/apps/fabric8mq-autoscaler/src/main/java/io/fabric8/mq/autoscaler/MQAutoScaler.java
@@ -211,14 +211,12 @@ public class MQAutoScaler implements MQAutoScalerMBean {
             MQAutoScalerObjectName = new ObjectName(DEFAULT_DOMAIN, "type", "mq-autoscaler");
             JMXUtils.registerMBean(this, MQAutoScalerObjectName);
 
-            KubernetesFactory kubernetesFactory = new KubernetesFactory();
-            kubernetes = new KubernetesClient(kubernetesFactory);
+            kubernetes = new KubernetesClient();
             clients = new JolokiaClients(kubernetes);
 
             timer = new Timer("MQAutoScaler timer");
             startTimerTask();
-            LOG.info("MQAutoScaler started, using Kubernetes master " + kubernetesFactory.getKubernetesMaster());
-
+            LOG.info("MQAutoScaler started, using Kubernetes master " + kubernetes.getAddress());
         }
     }
 


### PR DESCRIPTION
lets delegate to the KubernetesClient and let it figure out where the master is via env vars, service discovery or the ~/.kube/config file