### PR TITLE
upgrade to the latest docker plugin version and use a docker prefix which seems to be mostly mandatory now

### DIFF
--- a/apps/amqbroker/pom.xml
+++ b/apps/amqbroker/pom.xml
@@ -158,7 +158,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/api-registry/pom.xml
+++ b/apps/api-registry/pom.xml
@@ -317,7 +317,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/apiman/pom.xml
+++ b/apps/apiman/pom.xml
@@ -282,7 +282,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/app-library/pom.xml
+++ b/apps/app-library/pom.xml
@@ -333,7 +333,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/cdelivery/pom.xml
+++ b/apps/cdelivery/pom.xml
@@ -223,7 +223,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/chaos-monkey/pom.xml
+++ b/apps/chaos-monkey/pom.xml
@@ -149,7 +149,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/fabric8-forge/pom.xml
+++ b/apps/fabric8-forge/pom.xml
@@ -144,7 +144,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/fabric8-http-gateway/pom.xml
+++ b/apps/fabric8-http-gateway/pom.xml
@@ -119,7 +119,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/fabric8mq-autoscaler/pom.xml
+++ b/apps/fabric8mq-autoscaler/pom.xml
@@ -110,7 +110,7 @@
                 <configuration>
                   <images>
                     <image>
-                      <name>${docker.image}</name>
+                      <name>${docker.registryPrefix}${docker.image}</name>
                       <build>
                         <from>${docker.from}</from>
                         <assembly>

--- a/apps/fabric8mq-consumer/pom.xml
+++ b/apps/fabric8mq-consumer/pom.xml
@@ -104,7 +104,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/fabric8mq-controller/pom.xml
+++ b/apps/fabric8mq-controller/pom.xml
@@ -217,7 +217,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>${docker.image}</name>
+                            <name>${docker.registryPrefix}${docker.image}</name>
                             <build>
                                 <from>${docker.from}</from>
                                 <assembly>

--- a/apps/fabric8mq-producer/pom.xml
+++ b/apps/fabric8mq-producer/pom.xml
@@ -124,7 +124,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/fabric8mq/pom.xml
+++ b/apps/fabric8mq/pom.xml
@@ -235,7 +235,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>${docker.image}</name>
+                            <name>${docker.registryPrefix}${docker.image}</name>
                             <build>
                                 <from>${docker.from}</from>
                                 <assembly>

--- a/apps/hubot-notifier/pom.xml
+++ b/apps/hubot-notifier/pom.xml
@@ -149,7 +149,7 @@
         <configuration>
           <images>
             <image>
-              <name>${docker.image}</name>
+              <name>${docker.registryPrefix}${docker.image}</name>
               <build>
                 <from>${docker.from}</from>
                 <assembly>

--- a/apps/infinispan-server/pom.xml
+++ b/apps/infinispan-server/pom.xml
@@ -60,7 +60,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>${docker.image}</name>
+                            <name>${docker.registryPrefix}${docker.image}</name>
                             <build>
                                 <from>jboss/infinispan-server:7.0.0.Final</from>
                                 <assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         <docker.assembly.exportBaseDir>false</docker.assembly.exportBaseDir>
         <!-- TODO this can be removed once we upgrade the docker maven plugin -->
         <docker.assembly.exportBase>false</docker.assembly.exportBase>
-        <docker.maven.plugin.version>0.13.0</docker.maven.plugin.version>
-        <docker.registryPrefix />
+        <docker.maven.plugin.version>0.13.1</docker.maven.plugin.version>
+        <docker.registryPrefix>docker.io/</docker.registryPrefix>
 <!--
         <docker.registry>registry.hub.docker.com</docker.registry>
 -->


### PR DESCRIPTION
upgrade to the latest docker plugin version and use a docker prefix which seems to be mostly mandatory now