### PR TITLE
added non blank default for includes to avoid the include pattern being defaulted to `${CHAOS_MONKEY_INCLUDES}` if run from inside the fabric8 console

### DIFF
--- a/apps/chaos-monkey/src/main/fabric8/templateParameters.properties
+++ b/apps/chaos-monkey/src/main/fabric8/templateParameters.properties
@@ -2,7 +2,7 @@
 CHAOS_MONKEY_ROOM.value = #fabric8_${namespace}
 CHAOS_MONKEY_ROOM.description = The chat room to talk to
 
-CHAOS_MONKEY_INCLUDES.value =
+CHAOS_MONKEY_INCLUDES.value = *
 CHAOS_MONKEY_INCLUDES.description = Comma separated list of patterns for pods which should be considered for deletion
 
 CHAOS_MONKEY_EXCLUDES.value = letschat*,gogs*


### PR DESCRIPTION
added non blank default for includes to avoid the include pattern being defaulted to `${CHAOS_MONKEY_INCLUDES}` if run from inside the fabric8 console