### PR TITLE
add DOMAIN env var to jenkins so we can use it to autodefault the domains for each namespace

### DIFF
--- a/apps/jenkins/src/main/fabric8/env.properties
+++ b/apps/jenkins/src/main/fabric8/env.properties
@@ -1,3 +1,5 @@
+DOMAIN = ${DOMAIN}
+
 SEED_GIT_URL = ${SEED_GIT_URL}
 KUBERNETES_CLIENT_CERTIFICATE_FILE = /etc/secret-volume/admin-cert
 KUBERNETES_CLIENT_KEY_FILE = /etc/secret-volume/admin-key


### PR DESCRIPTION
add DOMAIN env var to jenkins so we can use it to autodefault the domains for each namespace