### PR TITLE
Upgrade Fabric8-version to 2.2.21 in quickstarts projects

### DIFF
--- a/quickstarts/java/camel-cdi-http/pom.xml
+++ b/quickstarts/java/camel-cdi-http/pom.xml
@@ -45,7 +45,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- the version of the BOM, defining all the dependency versions -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
     <camel.version>2.15.2</camel.version>

--- a/quickstarts/java/camel-cdi-mq/pom.xml
+++ b/quickstarts/java/camel-cdi-mq/pom.xml
@@ -43,7 +43,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- the version of the BOM, defining all the dependency versions -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
     <camel.version>2.15.2</camel.version>

--- a/quickstarts/java/camel-cdi-rest/pom.xml
+++ b/quickstarts/java/camel-cdi-rest/pom.xml
@@ -45,7 +45,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- the version of the BOM, defining all the dependency versions -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
     <camel.version>2.15.2</camel.version>

--- a/quickstarts/java/camel-cdi/pom.xml
+++ b/quickstarts/java/camel-cdi/pom.xml
@@ -45,7 +45,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- the version of the BOM, defining all the dependency versions -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
     <camel.version>2.15.2</camel.version>

--- a/quickstarts/java/camel-spring/pom.xml
+++ b/quickstarts/java/camel-spring/pom.xml
@@ -46,7 +46,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- the version of the BOM, defining all the dependency versions -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
 
     <!-- maven plugin versions -->
     <camel.version>2.15.2</camel.version>

--- a/quickstarts/java/cxf-cdi/pom.xml
+++ b/quickstarts/java/cxf-cdi/pom.xml
@@ -44,7 +44,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- the version of the BOM, defining all the dependency versions -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <fabric8.label.container>java</fabric8.label.container>
     <fabric8.label.group>quickstarts</fabric8.label.group>
 

--- a/quickstarts/java/jgroups-greeter/pom.xml
+++ b/quickstarts/java/jgroups-greeter/pom.xml
@@ -37,7 +37,7 @@
     <fabric8.generateJson>false</fabric8.generateJson>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
 

--- a/quickstarts/java/simple-fatjar/pom.xml
+++ b/quickstarts/java/simple-fatjar/pom.xml
@@ -42,7 +42,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
 

--- a/quickstarts/java/simple-mainclass/pom.xml
+++ b/quickstarts/java/simple-mainclass/pom.xml
@@ -42,7 +42,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
 

--- a/quickstarts/karaf/camel-amq/pom.xml
+++ b/quickstarts/karaf/camel-amq/pom.xml
@@ -39,7 +39,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
 
     <!-- the version of the BOM, defining all the dependency versions -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <!-- need to declare the Camel version as features-maven-plugin needs this property (cannot inherit from BOM in maven plugin) -->
     <activemq.version>5.11.1</activemq.version>
     <camel.version>2.15.2</camel.version>

--- a/quickstarts/karaf/camel-log/pom.xml
+++ b/quickstarts/karaf/camel-log/pom.xml
@@ -40,7 +40,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
     <camel.version>2.15.2</camel.version>

--- a/quickstarts/karaf/camel-rest-sql/pom.xml
+++ b/quickstarts/karaf/camel-rest-sql/pom.xml
@@ -39,7 +39,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
     <derby.version>10.10.2.0</derby.version>

--- a/quickstarts/karaf/cxf-rest/pom.xml
+++ b/quickstarts/karaf/cxf-rest/pom.xml
@@ -45,7 +45,7 @@
     <cxf-version-range>[3.0.4,3.0.5)</cxf-version-range>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
     <cxf.version>3.0.4</cxf.version>

--- a/quickstarts/spring-boot/activemq/pom.xml
+++ b/quickstarts/spring-boot/activemq/pom.xml
@@ -41,7 +41,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
 

--- a/quickstarts/spring-boot/camel/pom.xml
+++ b/quickstarts/spring-boot/camel/pom.xml
@@ -41,7 +41,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
     <camel.version>2.15.2</camel.version>

--- a/quickstarts/spring-boot/keycloak/pom.xml
+++ b/quickstarts/spring-boot/keycloak/pom.xml
@@ -41,7 +41,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
 

--- a/quickstarts/spring-boot/webmvc-ip/pom.xml
+++ b/quickstarts/spring-boot/webmvc-ip/pom.xml
@@ -41,7 +41,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
 

--- a/quickstarts/spring-boot/webmvc/pom.xml
+++ b/quickstarts/spring-boot/webmvc/pom.xml
@@ -41,7 +41,7 @@
     <integrationTestPattern>**/*KubernetesTest.java</integrationTestPattern>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
 

--- a/quickstarts/war/camel-servlet/pom.xml
+++ b/quickstarts/war/camel-servlet/pom.xml
@@ -42,7 +42,7 @@
     <skipTests>true</skipTests>
 
     <!-- the version of the BOM, defining all the dependency versions -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
 
     <docker.from>docker.io/fabric8/tomcat-8.0</docker.from>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>

--- a/quickstarts/war/cxf-cdi-servlet/pom.xml
+++ b/quickstarts/war/cxf-cdi-servlet/pom.xml
@@ -41,7 +41,7 @@
     <skipTests>true</skipTests>
 
     <!-- the version of the BOM, defining all the dependency versions -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
     <cxf.version>3.0.4</cxf.version>

--- a/quickstarts/war/rest/pom.xml
+++ b/quickstarts/war/rest/pom.xml
@@ -45,7 +45,7 @@
     <tomcat-plugin.version>2.2</tomcat-plugin.version>
 
     <!-- versions for use in mvn plugins as we cannot inherit them from a BOM -->
-    <fabric8.version>2.2.20</fabric8.version>
+    <fabric8.version>2.2.21</fabric8.version>
     <jube.version>2.2.0</jube.version>
     <docker.maven.plugin.version>0.13.2</docker.maven.plugin.version>
     <camel.version>2.15.2</camel.version>


### PR DESCRIPTION
Just an upgrade of Fabric8-version to the latest BOM.

I've changed the version in all projects except karaf4 camel-log :-)

Andrea